### PR TITLE
fix: docker buildx for publish docker images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
 	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
 	export BUILDX_NO_DEFAULT_ATTESTATIONS=1
-	- $(CONTAINER_TOOL) buildx create --name infini-operator-builder --use --driver-opt env.http_proxy=http://host.orb.internal:7890 --driver-opt env.https_proxy=http://host.orb.internal:7890 --config $(HOME)/.docker/buildx/buildkit.toml
+	- $(CONTAINER_TOOL) buildx create --name infini-operator-builder
 	$(CONTAINER_TOOL) buildx use infini-operator-builder
 	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --tag ${IMG} --cache-from=type=local,src=$(HOME)/.docker/.buildx-cache --cache-to=type=local,dest=$(HOME)/.docker/.buildx-cache,mode=max -f Dockerfile.cross .
 	- $(CONTAINER_TOOL) buildx rm infini-operator-builder


### PR DESCRIPTION
This pull request includes a minor update to the `Makefile` to simplify the `docker-buildx` target by removing proxy-related driver options during the creation of the `infini-operator-builder`. 

Build process simplification:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L125-R125): Removed the `--driver-opt` flags for `http_proxy` and `https_proxy` when creating the `infini-operator-builder` with `buildx`. This simplifies the build process by eliminating proxy configuration.